### PR TITLE
Fix File projectTimeActive

### DIFF
--- a/plugin/src/main/kotlin/com/almightyalpaca/jetbrains/plugins/discord/plugin/data/DataService.kt
+++ b/plugin/src/main/kotlin/com/almightyalpaca/jetbrains/plugins/discord/plugin/data/DataService.kt
@@ -156,7 +156,7 @@ class DataService {
                             projectName,
                             projectDescription,
                             projectTimeOpened,
-                            applicationTimeActive,
+                            projectTimeActive,
                             projectSettings,
                             vcsBranch,
                             debuggerActive,


### PR DESCRIPTION
This PR fixes an issue where the elapsed time for a file displays the `Application (active)` instead of the configured `Project (active)` time.