### PR TITLE
ipc: Bump KDiscordIPC and re-enable disconnect handling

### DIFF
--- a/libs.versions.toml
+++ b/libs.versions.toml
@@ -3,7 +3,7 @@ antlr                       = "4.11.1"
 commons-io                  = "2.11.0"
 commons-lang                = "3.12.0"
 commons-text                = "1.10.0"
-discord-ipc                 = "09bc0cc"
+discord-ipc                 = "0.2.2"
 discord-rpc                 = "2.0.2"
 docker                      = "3.2.13"
 gitversion                  = "0.15.0"
@@ -35,7 +35,7 @@ antlr-runtime                           = { group = "org.antlr", name = "antlr4-
 commons-io                              = { group = "commons-io", name = "commons-io", version.ref = "commons-io" }
 commons-lang                            = { group = "org.apache.commons", name = "commons-lang3", version.ref = "commons-lang" }
 commons-text                            = { group = "org.apache.commons", name = "commons-text", version.ref = "commons-text" }
-discord-ipc                             = { group = "com.github.cbyrneee", name = "KDiscordIPC", version.ref = "discord-ipc" }
+discord-ipc                             = { group = "com.github.caoimhebyrne", name = "KDiscordIPC", version.ref = "discord-ipc" }
 discord-rpc                             = { group = "club.minnced", name = "java-discord-rpc", version.ref = "discord-rpc" }
 docker                                  = { group = "com.github.docker-java", name = "docker-java", version.ref = "docker" }
 gradle-shadow                           = { group = "gradle.plugin.com.github.jengelman.gradle.plugins", name = "shadow", version.ref = "shadow" }

--- a/plugin/src/main/kotlin/com/almightyalpaca/jetbrains/plugins/discord/plugin/rpc/connection/DiscordIpcConnection.kt
+++ b/plugin/src/main/kotlin/com/almightyalpaca/jetbrains/plugins/discord/plugin/rpc/connection/DiscordIpcConnection.kt
@@ -24,6 +24,7 @@ import com.almightyalpaca.jetbrains.plugins.discord.plugin.utils.DisposableCorou
 import com.almightyalpaca.jetbrains.plugins.discord.plugin.utils.errorLazy
 import dev.cbyrne.kdiscordipc.KDiscordIPC
 import dev.cbyrne.kdiscordipc.core.event.impl.CurrentUserUpdateEvent
+import dev.cbyrne.kdiscordipc.core.event.impl.DisconnectedEvent
 import dev.cbyrne.kdiscordipc.core.event.impl.ErrorEvent
 import dev.cbyrne.kdiscordipc.core.event.impl.ReadyEvent
 import dev.cbyrne.kdiscordipc.data.activity.activity
@@ -46,6 +47,7 @@ class DiscordIpcConnection(override val appId: Long, private val userCallback: U
             on<ReadyEvent>(::onReady)
             on<ErrorEvent>(::onError)
             on<CurrentUserUpdateEvent>(::onCurrentUserUpdate)
+            on<DisconnectedEvent> { onDisconnect() }
         }
 //        setListener(this@DiscordIpcConnection)
     }
@@ -97,12 +99,10 @@ class DiscordIpcConnection(override val appId: Long, private val userCallback: U
         userCallback(event.data.toGeneric())
     }
 
-    // TODO: Register once the library exposes this again
-    // private fun onDisconnect(reason: String) {
-    //     DiscordPlugin.LOG.info("IPC disconnected: $reason")
-    //
-    //     userCallback(null)
-    // }
+    private fun onDisconnect() {
+        DiscordPlugin.LOG.info("IPC disconnected")
+        userCallback(null)
+    }
 }
 
 private fun NativeUser.toGeneric() = User.Normal(this.username, discriminator, this.id.toLong(), this.avatar)


### PR DESCRIPTION
Error handling has been improved, meaning that a lot of issues that people have been having (particularly on Linux) have been rectified.