### PR TITLE
Make ConnectionError.Failed not log.

### DIFF
--- a/plugin/src/main/kotlin/com/almightyalpaca/jetbrains/plugins/discord/plugin/rpc/connection/DiscordIpcConnection.kt
+++ b/plugin/src/main/kotlin/com/almightyalpaca/jetbrains/plugins/discord/plugin/rpc/connection/DiscordIpcConnection.kt
@@ -66,7 +66,7 @@ class DiscordIpcConnection(override val appId: Long, private val userCallback: U
                         ConnectionError.NoIPCFile -> disconnect()
                         ConnectionError.AlreadyConnected -> DiscordPlugin.LOG.errorLazy { "IPC already connected" }
                         ConnectionError.NotConnected -> DiscordPlugin.LOG.errorLazy { "IPC not connected" }
-                        ConnectionError.Failed -> DiscordPlugin.LOG.errorLazy { "IPC failed" }
+                        ConnectionError.Failed -> disconnect()
                         ConnectionError.Disconnected -> DiscordPlugin.LOG.errorLazy { "IPC disconnected" }
                     }
                 }

--- a/plugin/src/main/kotlin/com/almightyalpaca/jetbrains/plugins/discord/plugin/rpc/connection/DiscordIpcConnection.kt
+++ b/plugin/src/main/kotlin/com/almightyalpaca/jetbrains/plugins/discord/plugin/rpc/connection/DiscordIpcConnection.kt
@@ -66,7 +66,7 @@ class DiscordIpcConnection(override val appId: Long, private val userCallback: U
                         ConnectionError.NoIPCFile -> disconnect()
                         ConnectionError.AlreadyConnected -> DiscordPlugin.LOG.errorLazy { "IPC already connected" }
                         ConnectionError.NotConnected -> DiscordPlugin.LOG.errorLazy { "IPC not connected" }
-                        ConnectionError.Failed -> disconnect()
+                        ConnectionError.Failed -> DiscordPlugin.LOG.warn("IPC Failed")
                         ConnectionError.Disconnected -> DiscordPlugin.LOG.errorLazy { "IPC disconnected" }
                     }
                 }


### PR DESCRIPTION
I'm guessing the real reason for this issue happening now is that Discord still has an IPC file despite not running. However, since there's no non-brittle way to know if Discord is actually running, and KDiscordIPC doesn't let us know _why_ the connection failed, I figure the next best thing is just to not make the user know about it.

The drawback is that if there's an _actual_ problem preventing the rich presence from activating, the only way to know is to let the user discover it themselves by looking at their Discord instance.

Fixes #396 by hiding it. Not my favorite solution, but it's not reporting a problem to begin with.