### PR TITLE
Fix Gradle cache files being detected as Gradle DSL files

### DIFF
--- a/icons/src/main/resources/discord/languages/gradle.yaml
+++ b/icons/src/main/resources/discord/languages/gradle.yaml
@@ -1,9 +1,6 @@
 name: Gradle
 parent: text
 asset: gradle
-match:
-  path:
-    contains: .gradle/
 flavors:
   - name: Gradle Groovy
     parent: groovy


### PR DESCRIPTION
- Removing `.gradle/` path matching

I have checked the contents of .gradle folder inside projects and it mostly contains intermediate building files users should never touch + gradle dependencies sources and classes.

As such I'm removing the matcher line that overrides detection for file extensions inside those folder to use Gradle asset.
This allows library sources to be detected as their original language while still keeping files with the .gradle extension to be detected by the gradle flavors.

This also doesn't break projects that use multiple .gradle DSL files to handle gradle project build as they'd still be recognized by the Gradle Groovy flavor.

Known issue: this doesn't seem to fix .gradle.kts files that are still detected as "Kotlin Script" instead of Gradle Kotlin.
But I don't know how to give priority to this extension instead of the standard Kotlin Script one, feel free to suggest changes though.